### PR TITLE
Migrate from Python 2 to Python 3; from Qt 4 to Qt 5.

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
                     springbot.centerGround(HEIGHT)
                 else:
                     for node in springbot.nodes:
-                        node.pos.y += (HEIGHT/2)
+                        node.pos.y += (HEIGHT//2)
 
                 # controle de fps
                 clock = pygame.time.Clock()

--- a/editor/Makefile
+++ b/editor/Makefile
@@ -3,13 +3,13 @@
 all: ui_mainwindow.py ui_aboutdialog.py resource_rc.py
 
 ui_mainwindow.py: forms/mainwindow.ui
-	pyuic4 forms/mainwindow.ui > ui_mainwindow.py
+	pyuic5 forms/mainwindow.ui > ui_mainwindow.py
 
 ui_aboutdialog.py: forms/aboutdialog.ui
-	pyuic4 forms/aboutdialog.ui > ui_aboutdialog.py
+	pyuic5 forms/aboutdialog.ui > ui_aboutdialog.py
 
 resource_rc.py:	img/resource.qrc
-	pyrcc4 img/resource.qrc > resource_rc.py
+	pyrcc5 img/resource.qrc > resource_rc.py
 
 clean:
 	rm -f resource_rc.py* ui_aboutdialog.py* ui_mainwindow.py*

--- a/editor/editor.py
+++ b/editor/editor.py
@@ -1,11 +1,11 @@
 #! /usr/bin/python
 
 import sys
-from PyQt4 import QtGui
+from PyQt5 import QtGui, QtWidgets
 from mainwindow import MainWindow
 
 if __name__ == '__main__':
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
 
     window.showMaximized()

--- a/editor/mainwindow.py
+++ b/editor/mainwindow.py
@@ -1,7 +1,7 @@
 import sys
 sys.path.append('..')
 
-from PyQt4 import QtCore, QtGui
+from PyQt5 import QtGui, QtWidgets, QtCore
 from ui_mainwindow import Ui_MainWindow
 from ui_aboutdialog import Ui_Dialog
 
@@ -23,7 +23,7 @@ show_names = False
 # Lista de springbots
 springbots = []
 
-class MainWindow(QtGui.QMainWindow, Ui_MainWindow):
+class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
 
     #
     # Constroi janela principal do programa
@@ -31,35 +31,35 @@ class MainWindow(QtGui.QMainWindow, Ui_MainWindow):
     def __init__(self):
         global springbot
 
-        QtGui.QMainWindow.__init__(self)
+        QtWidgets.QMainWindow.__init__(self)
 
     # Set up the user interface from Designer.
         self.setupUi(self)
 
         # Cria objeto about dialog
-        self.aboutDialog = QtGui.QDialog()
+        self.aboutDialog = QtWidgets.QDialog()
         ui = Ui_Dialog()
         ui.setupUi(self.aboutDialog)
 
         # Cria timer e seta os slots
         self.timer = QtCore.QTimer(self)
-        QtCore.QObject.connect(self.timer,  QtCore.SIGNAL("timeout()"), self.space.refresh)
-        QtCore.QObject.connect(self.timer,  QtCore.SIGNAL("timeout()"), self.senoide, QtCore.SLOT("update()"))
-        QtCore.QObject.connect(self.timer,  QtCore.SIGNAL("timeout()"), self.space, QtCore.SLOT("update()"))
+        self.timer.timeout.connect(self.space.refresh)
+        self.timer.timeout.connect(self.senoide.update)
+        self.timer.timeout.connect(self.space.update)
 
         # Conecta as acoes com os metodos
-        QtCore.QObject.connect(self.toggleGravityAct, QtCore.SIGNAL("toggled(bool)"), self.toggleGravity)
-        QtCore.QObject.connect(self.toggleEditModeAct, QtCore.SIGNAL("toggled(bool)"), self.toggleEditMode)
-        QtCore.QObject.connect(self.killSpringbotAct, QtCore.SIGNAL("triggered(bool)"), self.killSpringbot)
-        QtCore.QObject.connect(self.loadSpringbotsAct, QtCore.SIGNAL("triggered(bool)"), self.loadSpringbots)
-        QtCore.QObject.connect(self.saveSpringbotsAct, QtCore.SIGNAL("triggered(bool)"), self.saveSpringbots)
-        QtCore.QObject.connect(self.changeNameAct, QtCore.SIGNAL("triggered(bool)"), self.changeName)
-        QtCore.QObject.connect(self.mutateAct, QtCore.SIGNAL("triggered(bool)"), self.mutate)
-        QtCore.QObject.connect(self.newRandomAct, QtCore.SIGNAL("triggered(bool)"), self.newRandom)
-        QtCore.QObject.connect(self.showMassCenterAct, QtCore.SIGNAL("toggled(bool)"), self.showMassCenter)
-        QtCore.QObject.connect(self.showNamesAct, QtCore.SIGNAL("toggled(bool)"), self.showNames)
-        QtCore.QObject.connect(self.aboutAct, QtCore.SIGNAL("triggered(bool)"), self.about)
-        QtCore.QObject.connect(self.crossoverAct, QtCore.SIGNAL("triggered(bool)"), self.crossover)
+        self.toggleGravityAct.toggled.connect(self.toggleGravity)
+        self.toggleEditModeAct.toggled.connect(self.toggleEditMode)
+        self.killSpringbotAct.triggered.connect(self.killSpringbot)
+        self.loadSpringbotsAct.triggered.connect(self.loadSpringbots)
+        self.saveSpringbotsAct.triggered.connect(self.saveSpringbots)
+        self.changeNameAct.triggered.connect(self.changeName)
+        self.mutateAct.triggered.connect(self.mutate)
+        self.newRandomAct.triggered.connect(self.newRandom)
+        self.showMassCenterAct.toggled.connect(self.showMassCenter)
+        self.showNamesAct.toggled.connect(self.showNames)
+        self.aboutAct.triggered.connect(self.about)
+        self.crossoverAct.triggered.connect(self.crossover)
 
         self.timer.start(30)
 
@@ -71,7 +71,7 @@ class MainWindow(QtGui.QMainWindow, Ui_MainWindow):
         global springbots
 
         if len(springbots) < 2:
-            QtGui.QMessageBox.warning(self, 'The number os springbots in the space must be equal or greater than two')
+            QtWidgets.QMessageBox.warning(self, 'Crossover', 'The number of springbots in the space must be equal or greater than two')
         else:
 
             # Pega tamanho da tela
@@ -131,8 +131,8 @@ class MainWindow(QtGui.QMainWindow, Ui_MainWindow):
             space.selected_springbot =  random.choice(springbots) if springbots else None
 
         else:
-            QtGui.QMessageBox.warning(self, 'Kill Springbot',
-                                      "Please select a Springbots to kill.", QtGui.QMessageBox.Ok)
+            QtWidgets.QMessageBox.warning(self, 'Kill Springbot',
+                                      "Please select a Springbots to kill.", QtWidgets.QMessageBox.Ok)
 
 
     #
@@ -148,8 +148,8 @@ class MainWindow(QtGui.QMainWindow, Ui_MainWindow):
             if ok:
                 space.selected_springbot.name = text
         else:
-            QtGui.QMessageBox.warning(self, 'Change name',
-                                      "Please select a Springbots first.", QtGui.QMessageBox.Ok)
+            QtWidgets.QMessageBox.warning(self, 'Change name',
+                                      "Please select a Springbots first.", QtWidgets.QMessageBox.Ok)
     #
     # Carrega Springbots
     #
@@ -195,8 +195,8 @@ class MainWindow(QtGui.QMainWindow, Ui_MainWindow):
             if filename:
                 store_xml(springbots, filename)
         else:
-            QtGui.QMessageBox.warning(self, 'Save springbots',
-                                      "There are no Springbots to save.", QtGui.QMessageBox.Ok)
+            QtWidgets.QMessageBox.warning(self, 'Save springbots',
+                                      "There are no Springbots to save.", QtWidgets.QMessageBox.Ok)
 
     #
     # Add New Random
@@ -231,8 +231,8 @@ class MainWindow(QtGui.QMainWindow, Ui_MainWindow):
             space.selected_springbot.mutate()
 
         else:
-            QtGui.QMessageBox.warning(self, 'Mutate Springbot',
-                                      "Please select a Springbot to mutate.", QtGui.QMessageBox.Ok)
+            QtWidgets.QMessageBox.warning(self, 'Mutate Springbot',
+                                      "Please select a Springbot to mutate.", QtWidgets.QMessageBox.Ok)
 
     #
     # About

--- a/editor/senoide.py
+++ b/editor/senoide.py
@@ -1,14 +1,14 @@
-from PyQt4 import QtGui, QtCore
+from PyQt5 import QtGui, QtWidgets, QtCore
 from math import pi, sin
 import mainwindow, space
 
-class Senoide(QtGui.QWidget):
+class Senoide(QtWidgets.QWidget):
 
     #
     # Construtor
     #
     def __init__(self, parent=None):
-        QtGui.QWidget.__init__(self, parent)
+        QtWidgets.QWidget.__init__(self, parent)
         self.setMouseTracking(True)
         self.setAutoFillBackground(False)
 
@@ -29,7 +29,7 @@ class Senoide(QtGui.QWidget):
         paint.drawRect(0, 0, width, height)
 
         paint.setBrush(QtGui.QColor(0, 0, 10))
-        paint.drawRect(width/6, 0, width*4/6, height)
+        paint.drawRect(width//6, 0, width*4//6, height)
         pen = QtGui.QPen()
 
         # Desenha linha media
@@ -37,7 +37,7 @@ class Senoide(QtGui.QWidget):
         pen.setWidth(4)
         paint.setPen(pen)
 
-        paint.drawLine(width/2, 0, width/2, height)
+        paint.drawLine(width//2, 0, width//2, height)
 
         if space.selected_springbot:
             # Desenha marcadores de springs
@@ -45,24 +45,24 @@ class Senoide(QtGui.QWidget):
             pen.setWidth(3)
             paint.setPen(pen)
             for spring in space.selected_springbot.springs:
-                paint.drawLine(0, (2*pi) + (spring.offset*height/(2*pi)), width, (2*pi) + (spring.offset*height/(2*pi)))
-                paint.drawEllipse((width/2) + (spring.amplitude*(width/2)) - 4, (2*pi) + (spring.offset*height/(2*pi)) - 4, 8, 8)
+                paint.drawLine(0, int((2*pi) + (spring.offset*height/(2*pi))), width, int((2*pi) + (spring.offset*height/(2*pi))))
+                paint.drawEllipse(int((width/2) + (spring.amplitude*(width/2)) - 4), int((2*pi) + (spring.offset*height/(2*pi)) - 4), 8, 8)
 
             if space.selected_spring:
                 pen.setColor(QtGui.QColor(100, 100, 0))
                 paint.setPen(pen)
-                paint.drawLine(0, (2*pi) + (space.selected_spring.offset*height/(2*pi)),
-                width, (2*pi) + (space.selected_spring.offset*height/(2*pi)))
-                paint.drawEllipse((width/2) + (space.selected_spring.amplitude*(width/2)) - 4,
-                (2*pi) + (space.selected_spring.offset*height/(2*pi)) - 4, 8, 8)
+                paint.drawLine(0, int((2*pi) + (space.selected_spring.offset*height/(2*pi))),
+                width, int((2*pi) + (space.selected_spring.offset*height/(2*pi))))
+                paint.drawEllipse(int((width/2) + (space.selected_spring.amplitude*(width/2)) - 4),
+                int((2*pi) + (space.selected_spring.offset*height/(2*pi)) - 4), 8, 8)
 
             if space.focus_spring and space.focus_spring.parent is space.selected_springbot:
                 pen.setColor(QtGui.QColor(50, 100, 0))
                 paint.setPen(pen)
-                paint.drawLine(0, (2*pi) + (space.focus_spring.offset*height/(2*pi)),
-                width, (2*pi) + (space.focus_spring.offset*height/(2*pi)))
-                paint.drawEllipse((width/2) + (space.focus_spring.amplitude*(width/2)) - 4,
-                (2*pi) + (space.focus_spring.offset*height/(2*pi)) - 4, 8, 8)
+                paint.drawLine(0, int((2*pi) + (space.focus_spring.offset*height/(2*pi))),
+                width, int((2*pi) + (space.focus_spring.offset*height/(2*pi))))
+                paint.drawEllipse(int((width/2) + (space.focus_spring.amplitude*(width/2)) - 4),
+                int((2*pi) + (space.focus_spring.offset*height/(2*pi)) - 4), 8, 8)
 
 
             # Desenha seno
@@ -70,11 +70,11 @@ class Senoide(QtGui.QWidget):
             pen.setWidth(2)
             paint.setPen(pen)
 
-            x = (width/2) + sin(space.selected_springbot['angle'])*(width/3)
+            x = int((width/2) + sin(space.selected_springbot['angle'])*(width/3))
             y = 0
-            for i in xrange(0,height,10):
-                paint.drawLine(x, y, (width/2) + (sin((i*pi*2/height)+space.selected_springbot['angle'])*(width/3)), i)
-                x = (width/2) + (sin((i*pi*2/height)+space.selected_springbot['angle'])*(width/3))
+            for i in range(0,height,10):
+                paint.drawLine(x, y, int((width/2) + (sin((i*pi*2/height)+space.selected_springbot['angle'])*(width/3))), i)
+                x = int((width/2) + (sin((i*pi*2/height)+space.selected_springbot['angle'])*(width/3)))
                 y = i
 
         paint.end()
@@ -91,10 +91,10 @@ class Senoide(QtGui.QWidget):
             # Verifica tamanho
             width, height = self.size().width(), self.size().height()
 
-            if event.x() < width/6.0:
-                x = width/6.0
-            elif event.x() > width*5.0/6.0:
-                x = width*5.0/6.0
+            if event.x() < width//6.0:
+                x = width//6.0
+            elif event.x() > width*5.0//6.0:
+                x = width*5.0//6.0
             else:
                 x = float(event.x())
 
@@ -119,10 +119,10 @@ class Senoide(QtGui.QWidget):
 
             if space.selected_spring and event.buttons() == QtCore.Qt.LeftButton:
 
-                if event.x() < width/6.0:
-                    x = width/6.0
-                elif event.x() > width*5.0/6.0:
-                    x = width*5.0/6.0
+                if event.x() < width//6.0:
+                    x = width//6.0
+                elif event.x() > width*5.0//6.0:
+                    x = width*5.0//6.0
                 else:
                     x = float(event.x())
 

--- a/editor/space.py
+++ b/editor/space.py
@@ -1,7 +1,7 @@
 import sys
 sys.path.append('..')
 
-from PyQt4 import QtGui, QtCore
+from PyQt5 import QtGui, QtWidgets, QtCore
 from springbots.evolvespringbot import *
 from springbots import gear
 from springbots.springbot import Springbot
@@ -32,13 +32,13 @@ CORES = [
 def dist(a, b):
     return math.sqrt((a[0]-b[0])**2+(a[1]-b[1])**2)
 
-class Space(QtGui.QWidget):
+class Space(QtWidgets.QWidget):
 
     #
     # Inicializa widget
     #
     def __init__(self, parent=None):
-        QtGui.QWidget.__init__(self, parent)
+        QtWidgets.QWidget.__init__(self, parent)
         self.setMouseTracking(True)
         self.setAutoFillBackground(False)
 
@@ -93,7 +93,7 @@ class Space(QtGui.QWidget):
 
             pen.setColor(QtGui.QColor(40, 40, 40))
             paint.setPen(pen)
-            paint.drawRoundRect(x1, y1, x2-x1, y2-y1)
+            paint.drawRoundedRect(x1, y1, x2-x1, y2-y1, 25.0, 25.0)
 
             # Se esta habilitado centro de massa
             if mainwindow.show_mass_center:
@@ -132,9 +132,9 @@ class Space(QtGui.QWidget):
                     fator = (length - spring.normal)/(length or 1)
 
                     if fator <= 0:
-                        color = (255, 255-min(-fator * 255, 255), 255-min(-fator * 255, 255))
+                        color = (255, 255-min(int(-fator * 255), 255), 255-min(int(-fator * 255), 255))
                     elif fator > 0:
-                        color = (255-min(fator * 255, 255), 255, 255-min(fator * 255, 255))
+                        color = (255-min(int(fator * 255), 255), 255, 255-min(int(fator * 255), 255))
 
                     pen.setColor(QtGui.QColor(*color))
 

--- a/evolve.py
+++ b/evolve.py
@@ -22,9 +22,6 @@ from springbots import fitness
 # To sample from the population
 from random import sample
 
-# To lowercase strings
-from string import lower
-
 try:
     import pygame
     HAS_PYGAME = True
@@ -65,12 +62,10 @@ def serial_evolve(population, fitness=fitness.walk, save_freq=100,
     randoms = int(len(population)/2 * random_insert)
 
     if verbose:
-        print "# Initiating simulation with a population of %d specimens." % (len(population))
-        print "# Evolving for %s:" % (fitness.__name__)
-        print "# At each iteration %d will be discarded, %d of the remaining will" % (
-            discarded, discarded-randoms),
-        print " be selected cloned and mutated and %d random springbots will be inserted" % (
-            randoms)
+        print("# Initiating simulation with a population of %d specimens." % (len(population)))
+        print("# Evolving for %s:" % (fitness.__name__))
+        print("# At each iteration %d will be discarded, %d of the remaining will" % (discarded, discarded-randoms), end=' ')
+        print(" be selected cloned and mutated and %d random springbots will be inserted" % (randoms))
 
     # Transforms population into evolvespringbots
     population = [EvolveSpringbot(springbot) for springbot in population]
@@ -80,7 +75,7 @@ def serial_evolve(population, fitness=fitness.walk, save_freq=100,
         while population and iter != limit:
 
             if verbose:
-                print "Iteration %d:" % (iter)
+                print("Iteration %d:" % (iter))
                 z = 1
                 fitness_sum = 0
                 bloodline_len_sum = 0
@@ -90,23 +85,23 @@ def serial_evolve(population, fitness=fitness.walk, save_freq=100,
                 specimen['fitness'] = fitness(specimen, WIDTH, HEIGHT, graphics)
 
                 if verbose:
-                    print "\t%d/%d: \"%s\"(%d) %.3f" % \
+                    print("\t%d/%d: \"%s\"(%d) %.3f" % \
                             (z, len(population), specimen['name'],
-                            specimen.generations(), specimen['fitness'])
+                            specimen.generations(), specimen['fitness']))
                     z += 1
                     bloodline_len_sum += specimen.generations()
                     fitness_sum += specimen['fitness']
 
             if verbose:
-                print "Bloodline lenght average: %.4f" % (bloodline_len_sum/float(len(population)))
-                print "Fitness average: %.4f" % (fitness_sum/float(len(population)))
+                print("Bloodline lenght average: %.4f" % (bloodline_len_sum/float(len(population))))
+                print("Fitness average: %.4f" % (fitness_sum/float(len(population))))
 
             # Now Order population by its fitness
             population.sort(
                 cmp=lambda A,B: cmp(A['fitness'], B['fitness']), reverse=True)
 
             # Discards some of the worse half
-            for specimen in sample(population[len(population)/2:], discarded + randoms):
+            for specimen in sample(population[len(population)//2:], discarded + randoms):
                 population.remove(specimen)
 
             # Clones and mutates some of the remaining
@@ -128,7 +123,7 @@ def serial_evolve(population, fitness=fitness.walk, save_freq=100,
                 population.append(child)
 
             # Incorporate randoms
-            population += [EvolveSpringbot(random=True) for x in xrange(randoms)]
+            population += [EvolveSpringbot(random=True) for x in range(randoms)]
 
             # Test if it is time to save population
             if iter % save_freq == 0:
@@ -137,7 +132,7 @@ def serial_evolve(population, fitness=fitness.walk, save_freq=100,
                 store_xml(population, filename)
 
                 if verbose:
-                    print "# iteration %d saved into %s" % (iter, filename)
+                    print("# iteration %d saved into %s" % (iter, filename))
 
             # Saves best if asked
             if best:
@@ -145,7 +140,7 @@ def serial_evolve(population, fitness=fitness.walk, save_freq=100,
                 store_xml(population[:1], filename)
 
                 if verbose:
-                    print "# Best of iteration %d saved into %s" % (iter, filename)
+                    print("# Best of iteration %d saved into %s" % (iter, filename))
 
             # Increments iteration
             iter += 1
@@ -154,15 +149,16 @@ def serial_evolve(population, fitness=fitness.walk, save_freq=100,
         pass
 
     # Order population by its fitness
-    population.sort(reverse=True)
+    population.sort(
+        cmp=lambda A,B: cmp(A['fitness'], B['fitness']), reverse=True)
 
     # Now, saves the current population and quit
     filename = "%s-%s-p%d-i%d.xml" % (prefix, fitness.__name__, len(population), iter)
     store_xml(population, filename)
     if verbose:
-        print
-        print "# iteration %d saved into %s" % (iter, filename)
-        print "# terminating..."
+        print()
+        print("# iteration %d saved into %s" % (iter, filename))
+        print("# terminating...")
 
 #
 # If this module its being running as main, execute main thread
@@ -204,8 +200,8 @@ if __name__ == "__main__":
     options.limit = int(options.limit)
     options.start_at = int(options.start_at)
 
-    options.prefix = options.prefix if options.prefix is not None else lower(latimname(3))
-    if options.verbose: print "# %s experiment." % options.prefix
+    options.prefix = options.prefix if options.prefix is not None else latimname(3).lower()
+    if options.verbose: print("# %s experiment." % options.prefix)
 
     if len(args) == 0:
         readfile = sys.stdin

--- a/fitness-server.py
+++ b/fitness-server.py
@@ -13,7 +13,7 @@ from springbots import fitness
 from springbots.networkspringbot import NetworkSpringbot
 
 # This is used to create the xmlrpc server
-import SimpleXMLRPCServer
+import xmlrpc.server
 
 try:
     import pygame
@@ -49,7 +49,7 @@ def quit():
         pygame.quit()
 
     if VERBOSE_MODE:
-        print "closing server..."
+        print("closing server...")
     server.server_close()
 
     return 0
@@ -83,7 +83,7 @@ def draw_waiting(msg):
     font = pygame.font.Font(None, 45)
     text = font.render(msg, True, (255,255,255))
     tw, th = text.get_size()
-    screen.blit(text, ((width/2)-(tw/2), (height/2)-(th/2)))
+    screen.blit(text, ((width//2)-(tw//2), (height//2)-(th//2)))
 
     pygame.display.flip()   # Show display
 
@@ -105,7 +105,7 @@ def fitness_test(marshal_springbot, function="walk"):
         draw_waiting("FITNESS: %.3f." % (springbot['fitness']))
 
     if VERBOSE_MODE:
-        print '"%s": %.3f' % (springbot['name'], springbot['fitness'])
+        print('"%s": %.3f' % (springbot['name'], springbot['fitness']))
 
     return springbot.marshal()
 
@@ -150,13 +150,13 @@ if __name__ == "__main__":
 
     # Create server
     try:
-        server = SimpleXMLRPCServer.SimpleXMLRPCServer(('', options.port))
-    except socket.error, err:
-        print err
+        server = xmlrpc.server.SimpleXMLRPCServer(('', options.port))
+    except socket.error as err:
+        print(err)
         sys.exit(1)
 
     if options.verbose:
-        print "Server listening on port %d" % (options.port)
+        print("Server listening on port %d" % (options.port))
 
     # Register functions
     server.register_function(fitness_test)

--- a/imagebot.py
+++ b/imagebot.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
 
         # Writes springbot structure to output
         writefile.write("<!-- ")
-        for key, value in springbot._info.iteritems():
+        for key, value in springbot._info.items():
             writefile.write('%s="%s" ' % (key, str(value)))
         writefile.write("-->\n")
 

--- a/log-plot.py
+++ b/log-plot.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     iter = None
     data = []
 
-    if options.verbose: print "reading log..."
+    if options.verbose: print("reading log...")
 
     if len(args) == 0:
         readfile = sys.stdin
@@ -84,7 +84,7 @@ if __name__ == "__main__":
                 sys.stderr.write("Error: bad log data at line %d: %s(broke iteration sequence)\n" % (d, line))
                 sys.exit(1)
 
-            if options.verbose: print "iteration %d" % new_iter
+            if options.verbose: print("iteration %d" % new_iter)
 
             iter = new_iter
             data.append({})
@@ -189,13 +189,13 @@ if __name__ == "__main__":
                 sys.stderr.write("Warning: %s have no data.\n" % name)
 
         if len(averages) == 1:
-            pylab.title("Fitness average for " + averages.keys()[0])
+            pylab.title("Fitness average for " + list(averages.keys())[0])
         else:
             pylab.title("Fitness average")
             pylab.legend()
 
     elif graph == INDIVIDUAL:
-        if options.verbose: print "processing data: individual fitness"
+        if options.verbose: print("processing data: individual fitness")
 
         # Start individual data
         individual = {}
@@ -220,7 +220,7 @@ if __name__ == "__main__":
                 else:
                     individual[test['name']] = ([n], [test['fitness']])
 
-        if options.verbose: print "processing plot"
+        if options.verbose: print("processing plot")
 
         # Plot graphs
         pylab.xlabel("iterations")
@@ -234,13 +234,13 @@ if __name__ == "__main__":
                 sys.stderr.write("Warning: %s have no data.\n" % name)
 
         if len(individual) == 1:
-            pylab.title("Fitness tests for " + individual.keys()[0])
+            pylab.title("Fitness tests for " + list(individual.keys())[0])
         else:
             pylab.title("Fitness tests")
             pylab.legend()
 
     elif graph == HISTOGRAM:
-        if options.verbose: print "processing graph: fitness histogram"
+        if options.verbose: print("processing graph: fitness histogram")
 
         # Start histogram data
         histogram = {}
@@ -265,7 +265,7 @@ if __name__ == "__main__":
                         histogram[test['name']] = [test['fitness']]
 
 
-        if options.verbose: print "processing plot"
+        if options.verbose: print("processing plot")
 
         # Plot
         pylab.xlabel("fitness")
@@ -283,12 +283,12 @@ if __name__ == "__main__":
             h.append(x[0])
 
         if len(histogram) == 1:
-            pylab.title("Fitness Histogram for " + histogram.keys()[0])
+            pylab.title("Fitness Histogram for " + list(histogram.keys())[0])
         else:
             pylab.title("Fitness Histogram")
-            pylab.legend(h,histogram.keys())
+            pylab.legend(h,list(histogram.keys()))
 
 
     # Show plot
-    if options.verbose: print "plotting"
+    if options.verbose: print("plotting")
     pylab.show()

--- a/net-evolve.py
+++ b/net-evolve.py
@@ -19,7 +19,7 @@ from springbots.latimname import latimname
 import sys, optparse
 
 # To call remote xmlrpc servers
-import xmlrpclib
+import xmlrpc.client
 
 # To sample from the population
 from random import sample
@@ -65,9 +65,9 @@ def load_servers():
     global servers, servers_lock, serverslist
 
     # Reads fitness servers
-    servers = [xmlrpclib.ServerProxy(strip(l)) for l in open(serverslist, 'r')
+    servers = [xmlrpc.client.ServerProxy(strip(l)) for l in open(serverslist, 'r')
                if len(strip(l)) > 0 and strip(l)[0] != '#']
-    servers_lock = [0 for x in xrange(len(servers))]
+    servers_lock = [0 for x in range(len(servers))]
 
 
 #                                                                              #
@@ -94,7 +94,7 @@ class FitnessThread(Thread):
         while True:
             try:
                 # Get the less used server at the moment
-                server_index = min(xrange(len(servers_lock)), key=servers_lock.__getitem__)
+                server_index = min(range(len(servers_lock)), key=servers_lock.__getitem__)
 
                 # Get the server object
                 server = servers[server_index]
@@ -115,7 +115,7 @@ class FitnessThread(Thread):
                 break
             except socket.error:
                 warn("Connection refused at server %s\n" % (str(server)))
-            except xmlrpclib.Error, err:
+            except xmlrpc.client.Error as err:
                 warn("Error at server %s: %s\n" % (str(server), str(err)))
 
         if not servers:
@@ -149,12 +149,12 @@ def network_evolve(save_freq=100, limit=-1,
     randoms = int(len(population)/2 * random_insert)
 
     if verbose:
-        print "# Initiating simulation with a population of %d specimens..." % (len(population))
-        print "# Evolving for %s:" % (fitness_function)
-        print "# At each iteration %d will be discarded, %d of the remaining will" % (
-            discarded, discarded-randoms),
-        print " be selected cloned and mutated and %d random springbots will be inserted" % (
-            randoms)
+        print("# Initiating simulation with a population of %d specimens..." % (len(population)))
+        print("# Evolving for %s:" % (fitness_function))
+        print("# At each iteration %d will be discarded, %d of the remaining will" % (
+            discarded, discarded-randoms), end=' ')
+        print(" be selected cloned and mutated and %d random springbots will be inserted" % (
+            randoms))
 
     # Turn all population into NetworkEvolveSpringbot
     population = [NetworkEvolveSpringbot(springbot) for springbot in population]
@@ -169,12 +169,12 @@ def network_evolve(save_freq=100, limit=-1,
             load_servers()
 
             if verbose:
-                print "Iteration %d:" % (iteration)
+                print("Iteration %d:" % (iteration))
                 fitness_sum = 0
                 bloodline_len_sum = 0
 
             # Create threads
-            threads = [FitnessThread(i) for i in xrange(len(population))]
+            threads = [FitnessThread(i) for i in range(len(population))]
 
             # Start all threads
             for thread in threads:
@@ -186,22 +186,22 @@ def network_evolve(save_freq=100, limit=-1,
 
                 if verbose:
                     specimen = population[thread.index]
-                    print "\t%d/%d: \"%s\"(%d) %.3f" % \
+                    print("\t%d/%d: \"%s\"(%d) %.3f" % \
                     (thread.index+1, len(population), specimen['name'],
-                    specimen.generations(), specimen['fitness'])
+                    specimen.generations(), specimen['fitness']))
                     bloodline_len_sum +=specimen.generations()
                     fitness_sum += specimen['fitness']
 
             if verbose:
-                print "Bloodline lenght average: %.4f" % (bloodline_len_sum/float(len(population)))
-                print "Fitness average: %.4f" % (fitness_sum/float(len(population)))
+                print("Bloodline lenght average: %.4f" % (bloodline_len_sum/float(len(population))))
+                print("Fitness average: %.4f" % (fitness_sum/float(len(population))))
 
             # Now Order population by its fitness
             population.sort(
                 cmp=lambda A,B: cmp(A['fitness'], B['fitness']), reverse=True)
 
             # Discards some of the worse half
-            for specimen in sample(population[len(population)/2:], discarded + randoms):
+            for specimen in sample(population[len(population)//2:], discarded + randoms):
                 population.remove(specimen)
 
             # Clones and mutates some of the remaining half
@@ -222,7 +222,7 @@ def network_evolve(save_freq=100, limit=-1,
                 population.append(child)
 
             # Incorporate randoms
-            population += [NetworkEvolveSpringbot(random=True) for x in xrange(randoms)]
+            population += [NetworkEvolveSpringbot(random=True) for x in range(randoms)]
 
             # Test if it is time to save population
             if iteration % save_freq == 0:
@@ -231,7 +231,7 @@ def network_evolve(save_freq=100, limit=-1,
                 store_xml(population, filename)
 
                 if verbose:
-                    print "# iteration %d saved into %s" % (iteration, filename)
+                    print("# iteration %d saved into %s" % (iteration, filename))
 
             # Saves best if asked
             if best:
@@ -239,7 +239,7 @@ def network_evolve(save_freq=100, limit=-1,
                 store_xml(population[:1], filename)
 
                 if verbose:
-                    print "# Best of iteration %d saved into %s" % (iteration, filename)
+                    print("# Best of iteration %d saved into %s" % (iteration, filename))
 
             # Increments iteration
             iteration += 1
@@ -247,7 +247,7 @@ def network_evolve(save_freq=100, limit=-1,
     except KeyboardInterrupt:
         pass
     if verbose:
-        print "# waiting for threads..."
+        print("# waiting for threads...")
 
     # Join(waits) all threads
     for thread in threads:
@@ -260,9 +260,9 @@ def network_evolve(save_freq=100, limit=-1,
     filename = "%s-%s-p%d-i%d.xml" % (prefix, fitness_function, len(population), iteration)
     store_xml(population, filename)
     if verbose:
-        print
-        print "# iteration %d saved into %s" % (iteration, filename)
-        print "# terminating..."
+        print()
+        print("# iteration %d saved into %s" % (iteration, filename))
+        print("# terminating...")
 
 #
 # If this module its being running as main, execute main thread
@@ -300,7 +300,7 @@ if __name__ == "__main__":
     options.start_at = int(options.start_at)
 
     options.prefix = options.prefix if options.prefix is not None else lower(latimname(3))
-    if options.verbose: print "# %s experiment." % options.prefix
+    if options.verbose: print("# %s experiment." % options.prefix)
 
     if len(args) == 0:
         readfile = sys.stdin

--- a/randombot.py
+++ b/randombot.py
@@ -29,4 +29,4 @@ if __name__ == "__main__":
     # writes it to XML output
     store_xml(\
             [random_springbot(options.nodes_num, options.springs_num, options.node_radius) \
-            for x in xrange(options.population)])
+            for x in range(options.population)])

--- a/springbots/evolvespringbot.py
+++ b/springbots/evolvespringbot.py
@@ -3,12 +3,12 @@ Springbot evolution extension.
 Implements genetic operations like mutation and crossover
 """
 
-from springbot import Springbot
-from gear import Node, Spring
+from .springbot import Springbot
+from .gear import Node, Spring
 from random import choice, uniform, randint
-from latimname import latimname
+from .latimname import latimname
 from math import sqrt, pi
-from vector import Vector
+from .vector import Vector
 from copy import copy
 
 #: Keep track of the bloodline id being generated
@@ -77,8 +77,8 @@ class EvolveSpringbot(Springbot):
             pass
 
         # For each spring in self and other
-        for springA, springB in zip(self.springs + ([None] * ((len(other.springs)-len(self.springs))/2)),
-                                    other.springs + ([None] * ((len(self.springs)-len(other.springs))/2))):
+        for springA, springB in zip(self.springs + ([None] * ((len(other.springs)-len(self.springs))//2)),
+                                    other.springs + ([None] * ((len(self.springs)-len(other.springs))//2))):
 
             if springA is None: springA = springB
             elif springB is None: springB = springA
@@ -142,7 +142,7 @@ class EvolveSpringbot(Springbot):
             return
 
         # Sorteia
-        tipo = choice(range(6))
+        tipo = choice(list(range(6)))
 
         if tipo == 0: # 0 - Adicao de node
             neigh = choice(self.nodes)
@@ -224,14 +224,14 @@ def random_springbot(nodes_num=10, springs_num=30, noderadius=100):
     springbot = EvolveSpringbot(name=latimname(5))
     springbot["adapted"] = "random"
 
-    for x in xrange(randint(nodes_num/2, nodes_num)):
+    for x in range(randint(nodes_num//2, nodes_num)):
         # Adiciona um node
         newnode = Node(pos=(uniform(-noderadius, noderadius),
                 uniform(-noderadius, noderadius)))
         springbot.add(newnode)  # Adiciona novo node
 
     if len(springbot.nodes) > 1:
-        for x in xrange(randint(springs_num/2, springs_num)):
+        for x in range(randint(springs_num//2, springs_num)):
             # Adiciona uma spring aleatoria
             a = choice(springbot.nodes)
             b = choice(springbot.nodes)

--- a/springbots/fitness.py
+++ b/springbots/fitness.py
@@ -9,9 +9,9 @@ swim: optimizes maximium difference of mass center before and after in a liquid 
 """
 
 # We need vector and gear to calculate some stuff
-from vector import Vector
+from .vector import Vector
 from math import sqrt
-import gear
+from . import gear
 
 try:
     import pygame
@@ -41,7 +41,7 @@ def walk(springbot, width, height, enable_graphics=False, simulation_time=1000):
         screen = pygame.display.get_surface()
 
     # Starts the simulation
-    for i in xrange(simulation_time):
+    for i in range(simulation_time):
         if enable_graphics and HAS_PYGAME:
             springbot.draw(screen, ticks, track_x=True, extrainfo="evolving for walk")
             pygame.display.flip()   # Show display
@@ -84,7 +84,7 @@ def jump(springbot, width, height, enable_graphics=False, simulation_time=500):
         screen = pygame.display.get_surface()
 
     # Starts the simulation
-    for i in xrange(simulation_time):
+    for i in range(simulation_time):
         if enable_graphics and HAS_PYGAME:
             springbot.draw(screen, ticks, extrainfo="evolving for jump")
             pygame.display.flip()   # Show display
@@ -131,7 +131,7 @@ def equilibrium(springbot, width, height, enable_graphics=False, simulation_time
         screen = pygame.display.get_surface()
 
     # Starts the simulation
-    for i in xrange(simulation_time):
+    for i in range(simulation_time):
         if enable_graphics and HAS_PYGAME:
             springbot.draw(screen, ticks, extrainfo="evolving for equilibrium")
             pygame.display.flip()   # Show display
@@ -180,7 +180,7 @@ def height(springbot, width, height, enable_graphics=False, simulation_time=400)
         screen = pygame.display.get_surface()
 
     # Starts the simulation
-    for i in xrange(simulation_time):
+    for i in range(simulation_time):
         if enable_graphics and HAS_PYGAME:
             springbot.draw(screen, ticks, extrainfo="evolving for height")
             pygame.display.flip()   # Show display
@@ -225,7 +225,7 @@ def swim(springbot, width, height, enable_graphics=False, simulation_time=1500):
 
     # Starts the simulation
     angle = 0.0
-    for i in xrange(simulation_time):
+    for i in range(simulation_time):
         if enable_graphics and HAS_PYGAME:
             springbot.draw(screen, ticks, track_x=True, track_y=True,
             backgroundcolor=(0,10,20), extrainfo="evolving for swim")

--- a/springbots/gear.py
+++ b/springbots/gear.py
@@ -5,7 +5,7 @@ among those parts.
 """
 
 from math import sqrt, pi, sin, log
-from vector import Vector
+from .vector import Vector
 
 #
 # Constants
@@ -69,7 +69,7 @@ class Node(object):
         """
         self.pos = self.pos + self.vel
         self.vel = self.vel + (self.acc * elast)
-        self.pos = self.pos + (self.acc * (1.0 - elast))
+        self.pos = self.pos + self.acc * (1.0 - elast)
         self.acc = Vector(0,0)
 
         self.vel = self.vel + Vector(grav[0], grav[1])
@@ -175,8 +175,8 @@ class Spring(object):
         N = self.normal + (sin(ang+self.offset) * ampl * self.normal)
 
         if dist != 0:
-            self.a.acc += (delta/dist * (N-dist) * (1.0-elast) * 0.5)
-            self.b.acc -= (delta/dist * (N-dist) * (1.0-elast) * 0.5)
+            self.a.acc += delta/dist * (N-dist) * (1.0-elast) * 0.5
+            self.b.acc -= delta/dist * (N-dist) * (1.0-elast) * 0.5
 
         # Aplica empuxo de fluido
         if visc > 0:
@@ -191,3 +191,6 @@ class Spring(object):
 
     def __repr__(self):
         return "<Spring normal=%.2f, amplitude=%.2f>" % (self.normal, self.amplitude)
+
+if __name__ == '__main__':
+    import unittest

--- a/springbots/latimname.py
+++ b/springbots/latimname.py
@@ -2,7 +2,6 @@
 This module has a function to generate a latim like name, but not latim at all
 """
 
-from string import upper
 from random import choice
 
 #: Latim vogals sylabes
@@ -23,7 +22,7 @@ def latimname(sil=5):
     """
     word = ''
     vog = choice([True, False])
-    for x in xrange(sil-1):
+    for x in range(sil-1):
         word += choice(VOG) if vog else choice(CONS+MIDCONS if x>0 else CONS)
         vog = not vog
 
@@ -32,4 +31,4 @@ def latimname(sil=5):
 
     word += choice(TERM) if choice([True, False]) else choice(VOG)
 
-    return upper(word[0]) + word[1:]
+    return word[0].upper() + word[1:]

--- a/springbots/networkspringbot.py
+++ b/springbots/networkspringbot.py
@@ -5,8 +5,8 @@ network by translating(two ways) the object itself to a simpler
 structure based on dictionary and tuples.
 """
 
-from springbot import Springbot
-from gear import Spring, Node
+from .springbot import Springbot
+from .gear import Spring, Node
 import exceptions
 
 #
@@ -23,7 +23,7 @@ class NetworkSpringbot(Springbot):
         Transforms the springbot into a dictionary
         """
         springbot_d = {}
-        for key, value in self._info.iteritems():
+        for key, value in self._info.items():
             springbot_d[key] = value
 
         springbot_d['nodes'] = tuple({'id': node.id,

--- a/springbots/springbot.py
+++ b/springbots/springbot.py
@@ -9,10 +9,10 @@ from warnings import warn
 # Rotinas para manuseamento de XML
 import xml.dom.minidom
 from xml.parsers.expat import ExpatError
-import exceptions
+# import exceptions
 
 # Importa as partes integrantes dos springbots
-from gear import *
+from .gear import *
 
 from math import sqrt, pi, fabs
 
@@ -73,7 +73,7 @@ class Springbot(object):
         return self._info[key] if key in self._info else ''
 
     def __setitem__(self, key, value):
-    	"""
+        """
         Gets an info inten like a dictionary
         """
         self._info[key] = value
@@ -285,7 +285,7 @@ class Springbot(object):
         x1, y1, x2, y2 = self.boundingBox()
 
         # Calculates horizontal center offset
-        cx = - ((x2+x1)/2)
+        cx = - ((x2+x1)//2)
 
         # Moves springbot to touch the ground under it
         # and moves sprinng bot to width center
@@ -311,17 +311,17 @@ class Springbot(object):
         # Gets the position center
         x1, y1, x2, y2 = self.boundingBox()
 
-        zm = min(min(width/((x2-x1)+50.0), height/((y2-y1)+50.0)), 1.0)
+        zm = min(min(width//((x2-x1)+50.0), height//((y2-y1)+50.0)), 1.0)
 
         if track_x:
-            cxp = (x2+x1)/2
-            cx = cxp*zm - (width/2)
+            cxp = (x2+x1)//2
+            cx = cxp*zm - (width//2)
         else:
-            cxp = cx = -width/2
+            cxp = cx = -width//2
 
         if track_y:
-            cyp = (y2+y1)/2
-            cy = cyp*zm - (height/2)
+            cyp = (y2+y1)//2
+            cy = cyp*zm - (height//2)
         else:
             cyp = cy = 0
 
@@ -333,12 +333,12 @@ class Springbot(object):
         # limpa tela
         screen.fill((0,0,0))
 
-        siz_x, siz_y = width/10, height/10
-        for x in xrange(0,width+100,siz_x):
-            for y in xrange(0,height+100,siz_y):
+        siz_x, siz_y = width//10, height//10
+        for x in range(0,width+100,siz_x):
+            for y in range(0,height+100,siz_y):
                 pygame.draw.rect(screen, backgroundcolor,
-                                 (((x - cxp) % (width+siz_x) - siz_x, (y - cyp) % (height+siz_y) - siz_y),
-                                  (siz_x-10,siz_y-10)))
+                                 (int(x - cxp) % (width+siz_x) - siz_x, int(y - cyp) % (height+siz_y) - siz_y,
+                                  siz_x-10,siz_y-10))
 
         # Desenha springs
         for spring in self.springs:
@@ -346,9 +346,9 @@ class Springbot(object):
             fator = (length - spring.normal)/length if length > 0 else 0
 
             if fator <= 0:
-                color = (255, 255-min(-fator * 255, 255), 255-min(-fator * 255, 255))
+                color = (255, 255-min(int(-fator * 255), 255), 255-min(int(-fator * 255), 255))
             elif fator > 0:
-                color = (255-min(fator * 255, 255), 255, 255-min(fator * 255, 255))
+                color = (255-min(int(fator * 255), 255), 255, 255-min(int(fator * 255), 255))
 
             pygame.draw.line(screen, color, (spring.a.pos.x*zm - cx, spring.a.pos.y*zm - cy),
                     (spring.b.pos.x*zm - cx, spring.b.pos.y*zm - cy), int(3*zm))
@@ -363,8 +363,8 @@ class Springbot(object):
             pygame.draw.circle(screen, (10,255,255), (int(node.pos.x*zm - cx), int(node.pos.y*zm - cy)),
                                int(RADIUS*zm), int(2*zm))
 
-        velx /= len(self.nodes)
-        vely /= len(self.nodes)
+        velx //= len(self.nodes)
+        vely //= len(self.nodes)
 
         if showText:
             # Render springbot's name and info
@@ -397,11 +397,11 @@ def store_xml(springbots, outfile=sys.stdout):
 
     for n, springbot in enumerate(springbots):
         x1, y1, x2, y2 = springbot.boundingBox()
-        cx, cy = (x1+x2)/2, (y1+y1)/2
+        cx, cy = (x1+x2)//2, (y1+y1)//2
 
         outfile.write('\t<springbot ')
 
-        for key, value in springbot._info.iteritems():
+        for key, value in springbot._info.items():
             outfile.write('%s="%s" ' % (key, str(value)))
 
         outfile.write('>\n')
@@ -450,7 +450,7 @@ def load_xml(arq=sys.stdin, limit=None):
         doc = xml.dom.minidom.parse(arq)
     except ExpatError:
         warn("springbot.loadXML: XML parse error at file %s." %
-                (arq.name if type(arq) == file else str(arq)))
+                (arq.name if type(arq) == type(sys.stdin) else str(arq)))
         return []
 
     # Lista de springbots
@@ -471,7 +471,7 @@ def load_xml(arq=sys.stdin, limit=None):
             # Cria novo springbot
             newspringbot = Springbot()
 
-            for key, value in springbotNode.attributes.items():
+            for key, value in list(springbotNode.attributes.items()):
                 newspringbot[key] = float(value) if isfloat(value) else \
                 (int(value) if value.isdigit() else value)
 

--- a/springbots/vector.py
+++ b/springbots/vector.py
@@ -10,7 +10,7 @@ def _is_numeric(obj):
     """
     Finds out if a variable is a numeric one
     """
-    if isinstance(obj, (int, long, float)):
+    if isinstance(obj, (int, float)):
         return True
     else:
         return False
@@ -53,13 +53,16 @@ class Vector(object):
         try:
             other = other - 0
         except:
-            raise TypeError, "Only scalar multiplication is supported."
+            raise TypeError("Only scalar multiplication is supported.")
         return Vector( other * self.x, other * self.y )
 
     def __rmul__(self, other):
         return self.__mul__(other)
 
     def __div__(self, other):
+        return Vector( self.x // other, self.y // other )
+
+    def __truediv__(self, other):
         return Vector( self.x / other, self.y / other )
 
     def __neg__(self):

--- a/viewer.py
+++ b/viewer.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
         springbot.centerGround(HEIGHT)
     else:
         for node in springbot.nodes:
-            node.pos.y += (HEIGHT/2)
+            node.pos.y += (HEIGHT//2)
 
     screen = pygame.display.get_surface()
 


### PR DESCRIPTION
Migrate from Python 2 to Python 3.
- Apply Python's "2to3". Examples of its effects: Puts parentheses around arguments to print( ). Imports packages by relative reference (example: .vector) not absolute reference (example: vector).
- Change some uses of the division operator to the integer division operator.
- Wrap some computations in int( ).

Migrate from PyQt 4 to PyQt 5.
- Use PyQt 5, pyuic5, and pyrcc5 rather than PyQt 4, pyuic4, and pyrcc4.
- Import QtWidgets from PyQt. Reference classes from QtWidgets that were formerly from QtGui. Give one QMessageBox a title because that's now a required parameter.
- In PyQt calls, use new-style signals not old-style signals.